### PR TITLE
feat: introduce control-plane/worker-runtime services and unified task contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,22 @@
 
 基于 OpenClaw 的多 Agent 分布式任务执行框架。
 
-## 架构
+## 架构（Control Plane / Worker Runtime 双进程）
 
 ```
-用户 → 主 Agent (本地) → 任务路由器 → 分发到合适的执行环境
-                                    │
-                    ┌───────────────┼───────────────┐
-                    ▼               ▼               ▼
-               本地执行        远程 Assistant    远程 Sandbox
-                                                  远程 Reviewer
+用户/调用方 → Control Plane API(HTTP gateway, 可扩展 gRPC)
+                        │
+                        ▼
+                  Task Router（调度输入）
+                        │
+                        ▼
+          统一协议 TaskSpec/TaskResult/Heartbeat/Lease
+                        │
+        ┌───────────────┴────────────────┐
+        ▼                                ▼
+ Message Queue（pull/push）          SSH fallback
+        ▼
+ Worker Runtime（capabilities: review/security/sandbox）
 ```
 
 ## 角色定义
@@ -23,10 +30,10 @@
 
 ## 使用方法
 
-### 检查系统健康
+### 启动 Control Plane API
 
 ```bash
-python main.py health
+python main.py api --host 0.0.0.0 --port 8080
 ```
 
 ### 任务路由测试
@@ -36,10 +43,10 @@ python main.py route "检查这段代码有没有bug"
 python main.py route "运行这个脚本"
 ```
 
-### 执行任务
+### 执行任务（统一协议）
 
 ```bash
-python main.py exec "帮我检查代码"
+python main.py exec "帮我检查代码" --priority high
 ```
 
 ### 完整测试
@@ -52,12 +59,20 @@ python main.py test
 
 ```
 multi-agent-framework/
+├── contracts/
+│   └── protocol.py         # TaskSpec/TaskResult/Heartbeat/Lease 协议
+├── proto/
+│   └── control_plane.proto # gRPC 协议草案
+├── services/
+│   ├── control-plane/      # 主 Agent API 服务
+│   ├── worker-runtime/     # 从 Agent 执行服务
+│   └── control_plane_loader.py
 ├── config/
 │   └── remote-agent.json    # 远程 Agent 配置
 ├── scripts/
 │   ├── task_router.py       # 任务路由器
-│   └── remote_executor.py   # 远程执行器
-├── main.py                 # 主控制器
+│   └── remote_executor.py   # 远程执行器（Gateway/MQ/SSH 适配器）
+├── main.py                 # 统一入口
 └── README.md
 ```
 

--- a/contracts/protocol.py
+++ b/contracts/protocol.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""统一协议定义：所有 agent 执行都使用结构化契约。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+import json
+import uuid
+
+
+class TaskPriority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass
+class TaskSpec:
+    task_id: str
+    title: str
+    payload: Dict[str, Any]
+    priority: TaskPriority = TaskPriority.MEDIUM
+    sla_seconds: int = 600
+    target_capability: Optional[str] = None
+    retry_count: int = 0
+    tags: List[str] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    @staticmethod
+    def new(title: str, payload: Dict[str, Any], **kwargs: Any) -> "TaskSpec":
+        return TaskSpec(task_id=str(uuid.uuid4()), title=title, payload=payload, **kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["priority"] = self.priority.value
+        return data
+
+
+@dataclass
+class TaskResult:
+    task_id: str
+    success: bool
+    output: Dict[str, Any]
+    error: Optional[str] = None
+    worker_id: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Heartbeat:
+    worker_id: str
+    load: float
+    queue_depth: int
+    capabilities: List[str]
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Lease:
+    worker_id: str
+    lease_id: str
+    expires_at: str
+
+    @staticmethod
+    def issue(worker_id: str, ttl_seconds: int = 30) -> "Lease":
+        expires = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+        return Lease(worker_id=worker_id, lease_id=str(uuid.uuid4()), expires_at=expires.isoformat())
+
+    def is_expired(self) -> bool:
+        return datetime.fromisoformat(self.expires_at) <= datetime.now(timezone.utc)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class WorkerRegistration:
+    worker_id: str
+    endpoint: str
+    capabilities: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def encode_message(message: Dict[str, Any]) -> str:
+    return json.dumps(message, ensure_ascii=False)
+
+
+def decode_message(raw: str) -> Dict[str, Any]:
+    return json.loads(raw)

--- a/main.py
+++ b/main.py
@@ -1,158 +1,86 @@
 #!/usr/bin/env python3
-"""
-多 Agent 协作框架 - 主控制器
-负责协调本地和远程 Agent 的任务执行
-"""
+"""多 Agent 框架入口：默认以 Control Plane API 方式运行。"""
 
+from __future__ import annotations
+
+import argparse
 import json
 import subprocess
 import sys
 from pathlib import Path
 
-# 添加脚本目录到路径
-sys.path.insert(0, str(Path(__file__).parent))
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-from scripts.task_router import TaskRouter
-from scripts.remote_executor import RemoteExecutor
+from contracts.protocol import TaskPriority, TaskSpec
+from services.control_plane_loader import build_controller
 
-class MultiAgentController:
-    def __init__(self):
-        self.router = TaskRouter()
-        self.executor = RemoteExecutor()
-        
-    def check_system_health(self) -> dict:
-        """检查系统健康状态"""
-        health = {
-            'local_connection': True,  # 本地始终可达
-            'remote_ssh': self.executor.check_remote_connection(),
-            'remote_openclaw': self.executor.test_remote_openclaw() if self.executor.check_remote_connection() else False
-        }
-        health['all_healthy'] = all(health.values())
-        return health
-    
-    def execute_task(self, task: str, force_remote: str = None) -> dict:
-        """
-        执行任务，自动选择执行环境
-        
-        Args:
-            task: 任务描述
-            force_remote: 强制使用远程 Agent (assistant/reviewer/sandbox)
-        """
-        # 1. 路由决策
-        if force_remote:
-            target = force_remote
-        else:
-            route_result = self.router.route(task)
-            target = route_result['target']
-        
-        # 2. 执行任务
-        if target == 'local':
-            return {
-                'executed_by': 'local',
-                'result': '本地执行（功能未实现）',
-                'task': task
-            }
-        else:
-            # 远程执行 - 使用 Gateway API 调用远程 Agent
-            # 优先使用 API 方式，失败则 fallback 到 SSH
-            result = self.executor.execute_task(task, agent_type=target, prefer_api=True)
-            
-            # 检查是否需要回退到 SSH
-            if not result.get('success', False) and 'Gateway API' in result.get('error', ''):
-                # API 失败，使用 SSH Shell 方式
-                remote_cmd = self._build_openclaw_command(task, target)
-                result = self.executor.execute_on_remote(remote_cmd)
-                result['method'] = 'ssh_shell_fallback'
-            
-            return {
-                'executed_by': f'remote_{target}',
-                'result': result,
-                'task': task,
-                'gateway': self.router.get_remote_gateway(),
-                'method': result.get('method', 'gateway_api')
-            }
-    
-    def _build_openclaw_command(self, task: str, agent_type: str) -> str:
-        """构建远程 OpenClaw 命令"""
-        prompt = self.router.build_remote_task(agent_type, task)
-        
-        # 使用 openclaw agent 命令执行任务
-        # 这里需要根据实际的 OpenClaw API 来调整
-        escaped_prompt = prompt.replace('"', '\\"').replace('\n', '\\n')
-        
-        cmd = f'echo "{escaped_prompt}" | openclaw agent --model bailian/MiniMax-M2.5'
-        
-        return cmd
-    
-    def test_full_pipeline(self) -> dict:
-        """测试完整流程"""
-        results = {
-            'health_check': self.check_system_health(),
-            'router_test': None,
-            'remote_execution_test': None
-        }
-        
-        # 测试路由器
-        test_tasks = [
-            "检查这段代码有没有bug",
-            "运行这个脚本",
-            "git commit -m 'test'"
-        ]
-        
-        router_results = []
-        for task in test_tasks:
-            route = self.router.route(task)
-            router_results.append({
-                'task': task,
-                'target': route['target'],
-                'risk': route['risk_level']
-            })
-        
-        results['router_test'] = router_results
-        
-        # 测试远程执行
-        if results['health_check']['remote_openclaw']:
-            test_result = self.executor.execute_on_remote('echo "Remote test OK"')
-            results['remote_execution_test'] = test_result
-        
-        return results
 
-def main():
-    controller = MultiAgentController()
-    
-    if len(sys.argv) > 1:
-        cmd = sys.argv[1]
-        
-        if cmd == 'health':
-            result = controller.check_system_health()
-            print(json.dumps(result, indent=2, ensure_ascii=False))
-            
-        elif cmd == 'test':
-            result = controller.test_full_pipeline()
-            print(json.dumps(result, indent=2, ensure_ascii=False))
-            
-        elif cmd == 'exec':
-            task = ' '.join(sys.argv[2:]) if len(sys.argv) > 2 else ''
-            if task:
-                result = controller.execute_task(task)
-                print(json.dumps(result, indent=2, ensure_ascii=False))
-            else:
-                print("Usage: python main.py exec <task>")
-        
-        elif cmd == 'route':
-            task = ' '.join(sys.argv[2:]) if len(sys.argv) > 2 else ''
-            if task:
-                result = controller.router.route(task)
-                print(json.dumps(result, indent=2, ensure_ascii=False))
-            else:
-                print("Usage: python main.py route <task>")
-        else:
-            print(f"Unknown command: {cmd}")
-            print("Available: health, test, exec, route")
-    else:
-        # 默认显示健康状态
-        result = controller.check_system_health()
+def run_api(host: str, port: int) -> int:
+    app_path = ROOT / "services" / "control-plane" / "app.py"
+    return subprocess.call([sys.executable, str(app_path), "--host", host, "--port", str(port)])
+
+
+def cli_submit_task(task: str, priority: str = "medium") -> dict:
+    controller = build_controller()
+    spec = TaskSpec.new(
+        title=task,
+        payload={"task": task},
+        priority=TaskPriority(priority),
+    )
+    result = controller.submit_task(spec)
+    return result.to_dict()
+
+
+def cli_health() -> dict:
+    controller = build_controller()
+    return {
+        "ok": True,
+        "workers": controller.registry.get_worker_snapshot(),
+        "gateway": controller.router.get_remote_gateway(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="multi-agent framework")
+    sub = parser.add_subparsers(dest="cmd")
+
+    api = sub.add_parser("api", help="run control-plane http gateway")
+    api.add_argument("--host", default="0.0.0.0")
+    api.add_argument("--port", type=int, default=8080)
+
+    health = sub.add_parser("health")
+
+    exec_parser = sub.add_parser("exec")
+    exec_parser.add_argument("task")
+    exec_parser.add_argument("--priority", default="medium", choices=[p.value for p in TaskPriority])
+
+    route = sub.add_parser("route")
+    route.add_argument("task")
+
+    args = parser.parse_args()
+
+    if args.cmd == "api":
+        return run_api(args.host, args.port)
+    if args.cmd == "health":
+        print(json.dumps(cli_health(), indent=2, ensure_ascii=False))
+        return 0
+    if args.cmd == "exec":
+        print(json.dumps(cli_submit_task(args.task, args.priority), indent=2, ensure_ascii=False))
+        return 0
+    if args.cmd == "route":
+        controller = build_controller()
+        result = controller.router.route(
+            args.task,
+            scheduling_input={"priority": "medium", "sla_seconds": 600, "retry_history": {"retry_count": 0}},
+        )
         print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    parser.print_help()
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/proto/control_plane.proto
+++ b/proto/control_plane.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package multiagent.v1;
+
+message TaskSpec {
+  string task_id = 1;
+  string title = 2;
+  string priority = 3;
+  int32 sla_seconds = 4;
+  string target_capability = 5;
+  int32 retry_count = 6;
+  map<string, string> payload = 7;
+  repeated string tags = 8;
+  string created_at = 9;
+}
+
+message TaskResult {
+  string task_id = 1;
+  bool success = 2;
+  string output_json = 3;
+  string error = 4;
+  string worker_id = 5;
+  string started_at = 6;
+  string finished_at = 7;
+}
+
+message Heartbeat {
+  string worker_id = 1;
+  float load = 2;
+  int32 queue_depth = 3;
+  repeated string capabilities = 4;
+  string timestamp = 5;
+}
+
+message Lease {
+  string worker_id = 1;
+  string lease_id = 2;
+  string expires_at = 3;
+}
+
+message RegisterWorkerRequest {
+  string worker_id = 1;
+  string endpoint = 2;
+  repeated string capabilities = 3;
+}
+
+message RegisterWorkerResponse {
+  bool success = 1;
+  Lease lease = 2;
+}
+
+service ControlPlaneService {
+  rpc SubmitTask(TaskSpec) returns (TaskResult);
+  rpc RegisterWorker(RegisterWorkerRequest) returns (RegisterWorkerResponse);
+  rpc SendHeartbeat(Heartbeat) returns (Lease);
+}

--- a/scripts/remote_executor.py
+++ b/scripts/remote_executor.py
@@ -12,10 +12,13 @@ import time
 import urllib.request
 import urllib.error
 from pathlib import Path
-from typing import Optional, Callable, List, Dict, Any
+from typing import Optional, Callable, List, Dict, Any, Protocol
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 import threading
+from queue import Queue, Empty
+
+from contracts.protocol import TaskSpec
 
 # 配置日志
 logging.basicConfig(
@@ -140,6 +143,62 @@ def cached(ttl: int = 300):
 _task_result_cache: Dict[str, tuple] = {}
 _task_cache_lock = threading.Lock()
 
+_TASK_QUEUE: "Queue[dict]" = Queue()
+_RESULT_QUEUE: "Queue[dict]" = Queue()
+
+
+class TransportAdapter(Protocol):
+    """传输层适配器接口。"""
+
+    def execute(self, task_payload: dict, agent_type: str) -> dict:
+        ...
+
+
+class GatewayTransportAdapter:
+    def __init__(self, executor: "RemoteExecutor"):
+        self.executor = executor
+
+    def execute(self, task_payload: dict, agent_type: str) -> dict:
+        prompt = json.dumps(task_payload, ensure_ascii=False)
+        return self.executor.execute_via_gateway_api(prompt=prompt, agent_type=agent_type)
+
+
+class SSHTransportAdapter:
+    def __init__(self, executor: "RemoteExecutor"):
+        self.executor = executor
+
+    def execute(self, task_payload: dict, agent_type: str) -> dict:
+        prompt = json.dumps(task_payload, ensure_ascii=False)
+        return self.executor.execute_task(task=prompt, agent_type=agent_type, prefer_api=False)
+
+
+class MessageQueueTransportAdapter:
+    """消息队列模式：支持 worker pull / push。"""
+
+    def __init__(self, result_timeout: int = 30):
+        self.result_timeout = result_timeout
+
+    def publish(self, task_payload: dict, agent_type: str) -> None:
+        _TASK_QUEUE.put({"agent_type": agent_type, "task": task_payload})
+
+    def consume(self, timeout: int = 1) -> Optional[dict]:
+        try:
+            return _TASK_QUEUE.get(timeout=timeout)
+        except Empty:
+            return None
+
+    def push_result(self, result: dict) -> None:
+        _RESULT_QUEUE.put(result)
+
+    def execute(self, task_payload: dict, agent_type: str) -> dict:
+        self.publish(task_payload=task_payload, agent_type=agent_type)
+        try:
+            result = _RESULT_QUEUE.get(timeout=self.result_timeout)
+            result["method"] = "mq"
+            return result
+        except Empty:
+            return {"success": False, "error": "消息队列执行超时", "method": "mq"}
+
 
 # ========== RemoteExecutor 类的性能优化方法 ==========
 
@@ -182,6 +241,11 @@ class RemoteExecutor:
     def __init__(self, config_path: str = None):
         self.config_path = config_path or CONFIG_PATH
         self.config = self._load_config()
+        self.adapters: Dict[str, TransportAdapter] = {
+            "gateway": GatewayTransportAdapter(self),
+            "ssh": SSHTransportAdapter(self),
+            "mq": MessageQueueTransportAdapter(),
+        }
         
     def _load_config(self) -> dict:
         with open(self.config_path, 'r', encoding='utf-8') as f:
@@ -521,6 +585,34 @@ export PATH=/home/zzc/.nvm/versions/node/v22.22.1/bin:$PATH
                 'method': 'ssh_openclaw_agent',
                 'agent_type': agent_type
             }
+
+    def execute_task_contract(self, spec: TaskSpec, agent_type: str = "assistant", prefer_transport: str = "auto") -> dict:
+        """统一协议执行入口，不直接拼接 shell 任务字符串。"""
+        payload = {
+            "task_spec": spec.to_dict(),
+            "execution_mode": "contract",
+        }
+        if prefer_transport == "mq":
+            return self.adapters["mq"].execute(payload, agent_type)
+        if prefer_transport == "gateway":
+            return self.adapters["gateway"].execute(payload, agent_type)
+        if prefer_transport == "ssh":
+            return self.adapters["ssh"].execute(payload, agent_type)
+
+        # auto: gateway -> mq -> ssh fallback
+        gateway_result = self.adapters["gateway"].execute(payload, agent_type)
+        if gateway_result.get("success"):
+            gateway_result["transport_path"] = ["gateway"]
+            return gateway_result
+
+        mq_result = self.adapters["mq"].execute(payload, agent_type)
+        if mq_result.get("success"):
+            mq_result["transport_path"] = ["gateway", "mq"]
+            return mq_result
+
+        ssh_result = self.adapters["ssh"].execute(payload, agent_type)
+        ssh_result["transport_path"] = ["gateway", "mq", "ssh"]
+        return ssh_result
     
     def _parse_agent_result(self, result: subprocess.CompletedProcess, agent_type: str, agent_id: str) -> dict:
         """

--- a/scripts/task_router.py
+++ b/scripts/task_router.py
@@ -54,7 +54,7 @@ class TaskRouter:
         
         return 'low'
     
-    def detect_trigger(self, task: str, context: dict = None) -> str:
+    def detect_trigger(self, task: str, context: dict = None, scheduling_input: dict = None) -> str:
         """
         检测任务应该发往哪个远程 Agent
         返回: 'assistant', 'reviewer', 'sandbox', 'local'
@@ -62,6 +62,7 @@ class TaskRouter:
         task_lower = task.lower()
         agents = self.config.get('agents', {})
         context = context or {}
+        scheduling_input = scheduling_input or {}
         
         # 1. 风险评估决定
         risk = self.assess_risk(task)
@@ -73,7 +74,28 @@ class TaskRouter:
         if any(kw in task_lower for kw in review_keywords):
             return 'reviewer'
         
-        # 3. 资源检查
+        # 3. 调度输入（替代纯关键词）：worker 负载、任务优先级、SLA、重试历史
+        worker_loads = scheduling_input.get('worker_loads', [])
+        priority = scheduling_input.get('priority', 'medium')
+        sla_seconds = scheduling_input.get('sla_seconds', 600)
+        retry_history = scheduling_input.get('retry_history', {})
+
+        has_reviewer = any('review' in (w.get('capabilities') or []) for w in worker_loads)
+        has_sandbox = any('sandbox' in (w.get('capabilities') or []) for w in worker_loads)
+        avg_load = (
+            sum(w.get('load', 0.0) for w in worker_loads) / len(worker_loads)
+            if worker_loads else 0
+        )
+        if risk == 'high' and has_sandbox:
+            return 'sandbox'
+        if priority in ('high', 'critical') and has_reviewer:
+            return 'reviewer'
+        if sla_seconds <= 120 or retry_history.get('retry_count', 0) >= 2:
+            return 'assistant'
+        if avg_load >= 0.8:
+            return 'assistant'
+
+        # 4. 资源检查（兼容旧字段）
         if context.get('cpu_usage', 0) > 80:
             return 'assistant'
         if context.get('queue_length', 0) > 5:
@@ -102,11 +124,11 @@ class TaskRouter:
 """
         return prompt
     
-    def route(self, task: str, context: dict = None) -> dict:
+    def route(self, task: str, context: dict = None, scheduling_input: dict = None) -> dict:
         """
         路由任务，返回执行计划
         """
-        target = self.detect_trigger(task, context)
+        target = self.detect_trigger(task, context, scheduling_input=scheduling_input)
         risk = self.assess_risk(task)
         
         result = {
@@ -114,7 +136,8 @@ class TaskRouter:
             'target': target,
             'risk_level': risk,
             'remote_gateway': self.get_remote_gateway() if target != 'local' else None,
-            'remote_prompt': self.build_remote_task(target, task) if target != 'local' else None
+            'remote_prompt': self.build_remote_task(target, task) if target != 'local' else None,
+            'scheduling_input': scheduling_input or {}
         }
         
         return result

--- a/services/control-plane/app.py
+++ b/services/control-plane/app.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Control Plane HTTP Gateway（可配合 gRPC service 使用）。"""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.protocol import TaskPriority, TaskSpec
+from services.control_plane_loader import build_controller
+
+
+controller = build_controller()
+
+
+class ControlPlaneHandler(BaseHTTPRequestHandler):
+    def _json(self, code: int, payload: dict):
+        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self._json(200, {"ok": True, "workers": controller.registry.get_worker_snapshot()})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+
+        if self.path == "/v1/tasks/submit":
+            spec = TaskSpec.new(
+                title=payload.get("title", "untitled"),
+                payload=payload.get("payload", {}),
+                priority=TaskPriority(payload.get("priority", "medium")),
+                sla_seconds=int(payload.get("sla_seconds", 600)),
+                target_capability=payload.get("target_capability"),
+                retry_count=int(payload.get("retry_count", 0)),
+                tags=payload.get("tags", []),
+            )
+            result = controller.submit_task(spec)
+            self._json(200, result.to_dict())
+            return
+
+        if self.path == "/v1/workers/register":
+            self._json(200, controller.register_worker(payload))
+            return
+
+        if self.path == "/v1/workers/heartbeat":
+            self._json(200, controller.receive_heartbeat(payload))
+            return
+
+        self._json(404, {"error": "not found"})
+
+
+def run(host: str = "0.0.0.0", port: int = 8080):
+    server = HTTPServer((host, port), ControlPlaneHandler)
+    print(f"control-plane gateway listening on http://{host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", default=8080, type=int)
+    args = parser.parse_args()
+    run(args.host, args.port)

--- a/services/control-plane/controller.py
+++ b/services/control-plane/controller.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Control Plane 编排核心。"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from contracts.protocol import Heartbeat, TaskResult, TaskSpec, WorkerRegistration
+from scripts.remote_executor import RemoteExecutor
+from scripts.task_router import TaskRouter
+from registry import WorkerRegistry
+
+
+class ControlPlaneController:
+    def __init__(self):
+        self.router = TaskRouter()
+        self.executor = RemoteExecutor()
+        self.registry = WorkerRegistry(lease_ttl_seconds=30)
+
+    def submit_task(self, spec: TaskSpec, force_target: Optional[str] = None) -> TaskResult:
+        workers = self.registry.get_worker_snapshot()
+        route = self.router.route(
+            spec.title,
+            scheduling_input={
+                "worker_loads": workers,
+                "priority": spec.priority.value,
+                "sla_seconds": spec.sla_seconds,
+                "retry_history": {"retry_count": spec.retry_count},
+            },
+        )
+        target = force_target or route["target"]
+
+        execution = self.executor.execute_task_contract(
+            spec=spec,
+            agent_type=target if target != "local" else "assistant",
+            prefer_transport="auto",
+        )
+        return TaskResult(
+            task_id=spec.task_id,
+            success=execution.get("success", False),
+            output=execution,
+            error=execution.get("error"),
+            worker_id=target,
+        )
+
+    def register_worker(self, payload: Dict[str, Any]) -> dict:
+        registration = WorkerRegistration(
+            worker_id=payload["worker_id"],
+            endpoint=payload.get("endpoint", ""),
+            capabilities=payload.get("capabilities", []),
+        )
+        lease = self.registry.register(registration)
+        return {"success": True, "lease": lease.to_dict()}
+
+    def receive_heartbeat(self, payload: Dict[str, Any]) -> dict:
+        heartbeat = Heartbeat(
+            worker_id=payload["worker_id"],
+            load=float(payload.get("load", 0.0)),
+            queue_depth=int(payload.get("queue_depth", 0)),
+            capabilities=payload.get("capabilities", []),
+        )
+        lease = self.registry.heartbeat(heartbeat)
+        if not lease:
+            return {"success": False, "error": "worker not registered"}
+        return {"success": True, "lease": lease.to_dict()}

--- a/services/control-plane/registry.py
+++ b/services/control-plane/registry.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Worker 注册中心：注册、心跳、租约过期摘除、能力标签管理。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Dict, List, Optional
+
+from contracts.protocol import Heartbeat, Lease, WorkerRegistration
+
+
+@dataclass
+class WorkerState:
+    registration: WorkerRegistration
+    lease: Lease
+    load: float = 0.0
+    queue_depth: int = 0
+    last_heartbeat: Optional[str] = None
+
+
+class WorkerRegistry:
+    def __init__(self, lease_ttl_seconds: int = 30):
+        self.lease_ttl_seconds = lease_ttl_seconds
+        self._workers: Dict[str, WorkerState] = {}
+        self._lock = Lock()
+
+    def register(self, worker: WorkerRegistration) -> Lease:
+        lease = Lease.issue(worker.worker_id, ttl_seconds=self.lease_ttl_seconds)
+        with self._lock:
+            self._workers[worker.worker_id] = WorkerState(registration=worker, lease=lease)
+        return lease
+
+    def heartbeat(self, hb: Heartbeat) -> Optional[Lease]:
+        with self._lock:
+            self.evict_expired_locked()
+            state = self._workers.get(hb.worker_id)
+            if not state:
+                return None
+            state.load = hb.load
+            state.queue_depth = hb.queue_depth
+            state.last_heartbeat = hb.timestamp
+            state.registration.capabilities = hb.capabilities
+            state.lease = Lease.issue(hb.worker_id, ttl_seconds=self.lease_ttl_seconds)
+            return state.lease
+
+    def evict_expired_locked(self) -> None:
+        expired = [wid for wid, s in self._workers.items() if s.lease.is_expired()]
+        for wid in expired:
+            self._workers.pop(wid, None)
+
+    def evict_expired(self) -> None:
+        with self._lock:
+            self.evict_expired_locked()
+
+    def list_workers(self) -> List[WorkerState]:
+        with self._lock:
+            self.evict_expired_locked()
+            return list(self._workers.values())
+
+    def get_worker_snapshot(self) -> List[dict]:
+        return [
+            {
+                "worker_id": s.registration.worker_id,
+                "endpoint": s.registration.endpoint,
+                "capabilities": s.registration.capabilities,
+                "load": s.load,
+                "queue_depth": s.queue_depth,
+                "last_heartbeat": s.last_heartbeat,
+                "lease_expires_at": s.lease.expires_at,
+                "now": datetime.now(timezone.utc).isoformat(),
+            }
+            for s in self.list_workers()
+        ]

--- a/services/control_plane_loader.py
+++ b/services/control_plane_loader.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""兼容 `services/control-plane` 目录名的动态加载器。"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+def build_controller():
+    control_plane_dir = Path(__file__).resolve().parent / "control-plane"
+    controller_path = control_plane_dir / "controller.py"
+    if str(control_plane_dir) not in sys.path:
+        sys.path.insert(0, str(control_plane_dir))
+    spec = importlib.util.spec_from_file_location("control_plane_controller", controller_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module.ControlPlaneController()

--- a/services/worker-runtime/app.py
+++ b/services/worker-runtime/app.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Worker Runtime 进程入口。"""
+
+from worker import WorkerRuntime
+
+
+def main():
+    runtime = WorkerRuntime(worker_id="worker-local-1", capabilities=["review", "security", "sandbox"])
+    runtime.run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/worker-runtime/worker.py
+++ b/services/worker-runtime/worker.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Worker Runtime：从消息队列 pull 任务并 push 结果。"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.remote_executor import MessageQueueTransportAdapter
+
+
+class WorkerRuntime:
+    def __init__(self, worker_id: str, capabilities: list[str]):
+        self.worker_id = worker_id
+        self.capabilities = capabilities
+        self.mq = MessageQueueTransportAdapter()
+
+    def run_forever(self, poll_interval: float = 1.0):
+        print(f"worker-runtime [{self.worker_id}] started, capabilities={self.capabilities}")
+        while True:
+            task_msg = self.mq.consume(timeout=1)
+            if not task_msg:
+                time.sleep(poll_interval)
+                continue
+
+            task_payload = task_msg.get("task", {})
+            result = {
+                "success": True,
+                "worker_id": self.worker_id,
+                "output": {
+                    "echo": task_payload,
+                    "processed_at": datetime.now(timezone.utc).isoformat(),
+                },
+                "method": "mq_worker_push",
+            }
+            self.mq.push_result(result)
+
+
+if __name__ == "__main__":
+    worker = WorkerRuntime(worker_id="worker-local-1", capabilities=["review", "security", "sandbox"])
+    worker.run_forever()


### PR DESCRIPTION
### Motivation
- Separate orchestration and execution into distinct process boundaries so the control plane can expose APIs and workers can pull work independently.
- Define a unified, structured protocol for tasks, results, heartbeats and leases so all agent executions use the same contract instead of ad-hoc shell strings.
- Provide pluggable transport adapters (gateway/mq/ssh) and richer scheduling input to support MQ-based worker pull/push and SLA-aware routing.

### Description
- Added `contracts/protocol.py` and `proto/control_plane.proto` with `TaskSpec/TaskResult/Heartbeat/Lease` types and a gRPC service draft for the control plane.
- Split runtime into `services/control-plane/` (HTTP gateway `app.py`, controller `controller.py`, registry `registry.py`, loader `control_plane_loader.py`) and `services/worker-runtime/` (worker runtime `worker.py` and `app.py`) process boundaries.
- Reworked `main.py` to be API-first with a `api` subcommand and CLI compatibility (`health`, `route`, `exec`) that talks to the control plane loader.
- Refactored `scripts/remote_executor.py` to introduce transport adapters: `GatewayTransportAdapter`, `MessageQueueTransportAdapter` (in-process MQ scaffold for pull/push), and `SSHTransportAdapter`, plus a unified entry `execute_task_contract` that falls back `gateway -> mq -> ssh`.
- Extended `scripts/task_router.py` to accept scheduling inputs (`worker_loads`, `priority`, `sla_seconds`, `retry_history`) and use them (plus worker capability tags `review/security/sandbox`) for routing decisions instead of keyword-only routing.
- Implemented worker registration, heartbeat renewal, lease issuance and eviction in the control-plane registry and surfaced these endpoints in the HTTP gateway (`/v1/tasks/submit`, `/v1/workers/register`, `/v1/workers/heartbeat`).
- Updated `README.md` to document the new architecture, contracts, and usage commands.

### Testing
- Ran static compile checks with `python -m py_compile main.py contracts/protocol.py services/control-plane/app.py services/control-plane/controller.py services/control-plane/registry.py services/worker-runtime/worker.py scripts/task_router.py scripts/remote_executor.py` and it succeeded.
- Exercised routing with `python main.py route "请审查这段代码"` and the router returned the expected plan including `scheduling_input` and target `reviewer` (succeeded).
- Queried control plane health with `python main.py health` and received the `workers` snapshot (succeeded).
- Ran `python main.py exec "测试任务" --priority high`; gateway returned `403` and SSH was unreachable in this environment so the `execute_task_contract` path exercised fallbacks and returned a failed execution as expected (transport fallback behavior observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be192429c88331a338eb03e0f62f4f)